### PR TITLE
Ensure Expo workspace uses single React instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "packages/*"
   ],
   "scripts": {
-    "dev:mobile": "npm run start --workspace @english/mobile",
-    "android": "npm run android --workspace @english/mobile",
-    "ios": "npm run ios --workspace @english/mobile",
-    "web": "npm run web --workspace @english/mobile",
-    "check:types": "npm run typecheck --workspace @english/mobile",
+    "dev:mobile": "node scripts/ensure-single-react.js && npm run start --workspace @english/mobile",
+    "android": "node scripts/ensure-single-react.js && npm run android --workspace @english/mobile",
+    "ios": "node scripts/ensure-single-react.js && npm run ios --workspace @english/mobile",
+    "web": "node scripts/ensure-single-react.js && npm run web --workspace @english/mobile",
+    "check:types": "node scripts/ensure-single-react.js && npm run typecheck --workspace @english/mobile",
     "dev:backend": "npm run dev --workspace backend",
     "build:backend": "npm run build --workspace backend",
     "dev:preview": "npm run dev --workspace @english/mobile-preview",

--- a/scripts/ensure-single-react.js
+++ b/scripts/ensure-single-react.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const workspaceRoot = path.join(repoRoot, 'apps', 'mobile');
+const nodeModules = path.join(workspaceRoot, 'node_modules');
+
+const ensureSymlink = (pkg) => {
+  const workspacePath = path.join(nodeModules, pkg);
+  const rootPath = path.join(repoRoot, 'node_modules', pkg);
+
+  if (!fs.existsSync(rootPath)) {
+    throw new Error(`Cannot find root installation for ${pkg} at ${rootPath}`);
+  }
+
+  if (fs.existsSync(workspacePath)) {
+    const stats = fs.lstatSync(workspacePath);
+    const alreadyLinked = stats.isSymbolicLink() && fs.realpathSync(workspacePath) === rootPath;
+    if (alreadyLinked) {
+      return;
+    }
+
+    fs.rmSync(workspacePath, { recursive: true, force: true });
+  }
+
+  fs.mkdirSync(path.dirname(workspacePath), { recursive: true });
+
+  // Use junction on Windows for compatibility with directories
+  fs.symlinkSync(rootPath, workspacePath, 'junction');
+};
+
+const main = () => {
+  if (!fs.existsSync(workspaceRoot)) {
+    return;
+  }
+
+  ensureSymlink('react');
+  ensureSymlink('react-dom');
+};
+
+main();


### PR DESCRIPTION
## Summary
- add a helper script that symlinks the mobile workspace's React packages to the hoisted copies
- invoke the helper before every Expo workspace command so only a single React instance is used

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e424cd60608325a5bbc15b5251cf88