### PR TITLE
feat: add shared ui components and theme

### DIFF
--- a/packages/shared/src/theme/index.ts
+++ b/packages/shared/src/theme/index.ts
@@ -1,0 +1,69 @@
+export type ThemeShadow = {
+  color: string;
+  opacity: number;
+  radius: number;
+  elevation: number;
+  offset: { width: number; height: number };
+};
+
+export type AppTheme = {
+  colors: {
+    background: string;
+    backgroundAlt: string;
+    surface: string;
+    surfaceAlt: string;
+    border: string;
+    text: string;
+    textSecondary: string;
+    primary: string;
+    danger: string;
+  };
+  radius: {
+    sm: number;
+    md: number;
+    lg: number;
+  };
+  spacing: {
+    xs: number;
+    sm: number;
+    md: number;
+    lg: number;
+  };
+  shadow: {
+    card: ThemeShadow;
+  };
+};
+
+export const lightTheme: AppTheme = {
+  colors: {
+    background: '#F3F4F6',
+    backgroundAlt: '#F9FAFB',
+    surface: '#FFFFFF',
+    surfaceAlt: '#F1F5F9',
+    border: '#E5E7EB',
+    text: '#1F2937',
+    textSecondary: '#6B7280',
+    primary: '#1E88E5',
+    danger: '#D32F2F',
+  },
+  radius: {
+    sm: 8,
+    md: 12,
+    lg: 20,
+  },
+  spacing: {
+    xs: 4,
+    sm: 8,
+    md: 16,
+    lg: 24,
+  },
+  shadow: {
+    card: {
+      color: 'rgba(15, 23, 42, 0.18)',
+      opacity: 0.12,
+      radius: 12,
+      elevation: 3,
+      offset: { width: 0, height: 6 },
+    },
+  },
+};

--- a/packages/shared/src/theme/styled.d.ts
+++ b/packages/shared/src/theme/styled.d.ts
@@ -1,0 +1,8 @@
+import 'styled-components/native';
+
+import type { AppTheme } from './index';
+
+declare module 'styled-components/native' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface DefaultTheme extends AppTheme {}
+}

--- a/packages/shared/src/ui/PrimaryButton.tsx
+++ b/packages/shared/src/ui/PrimaryButton.tsx
@@ -1,0 +1,60 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import type { TouchableOpacityProps } from 'react-native';
+import styled from 'styled-components/native';
+
+import { Typography } from './Typography';
+
+export type PrimaryButtonProps = PropsWithChildren<
+  TouchableOpacityProps & {
+    label?: string;
+    loading?: boolean;
+    loadingLabel?: string;
+  }
+>;
+
+const ButtonContainer = styled.TouchableOpacity`
+  background-color: ${({ theme }) => theme.colors.primary};
+  border-radius: ${({ theme }) => theme.radius.md}px;
+  padding: 14px 20px;
+  align-items: center;
+  justify-content: center;
+  opacity: ${({ disabled }) => (disabled ? 0.6 : 1)};
+`;
+
+const ButtonLabel = styled(Typography)`
+  color: #ffffff;
+  font-weight: 600;
+`;
+
+export const PrimaryButton = ({
+  children,
+  label,
+  loading = false,
+  loadingLabel = 'Загрузка...',
+  disabled,
+  ...rest
+}: PrimaryButtonProps) => {
+  const isDisabled = disabled || loading;
+
+  const content: ReactNode = (() => {
+    if (loading) {
+      return <ButtonLabel>{loadingLabel}</ButtonLabel>;
+    }
+    if (typeof children === 'string' || typeof children === 'number') {
+      return <ButtonLabel>{children}</ButtonLabel>;
+    }
+    if (children) {
+      return children;
+    }
+    if (label) {
+      return <ButtonLabel>{label}</ButtonLabel>;
+    }
+    return null;
+  })();
+
+  return (
+    <ButtonContainer activeOpacity={0.8} disabled={isDisabled} {...rest}>
+      {content}
+    </ButtonContainer>
+  );
+};

--- a/packages/shared/src/ui/SurfaceCard.tsx
+++ b/packages/shared/src/ui/SurfaceCard.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components/native';
+
+export type SurfaceCardProps = {
+  padded?: boolean;
+};
+
+export const SurfaceCard = styled.View<SurfaceCardProps>`
+  background-color: ${({ theme }) => theme.colors.surface};
+  border-radius: ${({ theme }) => theme.radius.lg}px;
+  border-width: 1px;
+  border-color: ${({ theme }) => theme.colors.border};
+  padding: ${({ padded }) => (padded ? '20px' : '16px')};
+`;

--- a/packages/shared/src/ui/Typography.tsx
+++ b/packages/shared/src/ui/Typography.tsx
@@ -1,0 +1,62 @@
+import type { PropsWithChildren } from 'react';
+import type { TextProps } from 'react-native';
+import { css } from 'styled-components';
+import styled from 'styled-components/native';
+
+export type TypographyVariant = 'title' | 'subtitle' | 'body' | 'caption';
+
+export type TypographyProps = PropsWithChildren<
+  TextProps & {
+    variant?: TypographyVariant;
+    color?: string;
+    align?: 'left' | 'center' | 'right';
+  }
+>;
+
+const StyledText = styled.Text<{
+  $variant: TypographyVariant;
+  $color?: string;
+  $align: 'left' | 'center' | 'right';
+}>`
+  color: ${({ theme, $color }) => $color ?? theme.colors.text};
+  text-align: ${({ $align }) => $align};
+  ${({ $variant, theme }) => {
+    switch ($variant) {
+      case 'title':
+        return css`
+          font-size: 28px;
+          font-weight: 700;
+        `;
+      case 'subtitle':
+        return css`
+          font-size: 20px;
+          font-weight: 600;
+        `;
+      case 'caption':
+        return css`
+          font-size: 14px;
+          font-weight: 400;
+          color: ${theme.colors.textSecondary};
+        `;
+      case 'body':
+      default:
+        return css`
+          font-size: 16px;
+          font-weight: 400;
+        `;
+    }
+  }}
+`;
+
+export const Typography = ({
+  children,
+  variant = 'body',
+  color,
+  align = 'left',
+  style,
+  ...rest
+}: TypographyProps) => (
+  <StyledText $variant={variant} $color={color} $align={align} style={style} {...rest}>
+    {children}
+  </StyledText>
+);

--- a/packages/shared/src/ui/index.ts
+++ b/packages/shared/src/ui/index.ts
@@ -1,0 +1,3 @@
+export * from './Typography';
+export * from './SurfaceCard';
+export * from './PrimaryButton';

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "jsx": "react-jsx",
     "composite": false,
     "declaration": false,
     "noEmit": true


### PR DESCRIPTION
## Summary
- add shared typography, card, and primary button components exported under @shared/ui
- provide a shared light theme definition and styled-components theme typings
- update the shared TypeScript config so the package can compile TSX sources

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e42dac103c83258680526941bcb3c1